### PR TITLE
autogen.sh: Drop unnecessary package checks

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -134,7 +134,7 @@ test $TEST_TYPE $FILE || {
 }
 
 if test -z "$ACLOCAL_FLAGS"; then
-    m4list="glib-2.0.m4 glib-gettext.m4 intltool.m4 pkg.m4"
+    m4list="pkg.m4"
     acdir0=`$ACLOCAL --print-ac-dir`
     acpaths=`echo "${ACLOCAL_PATH}:${acdir0}" | sed 's/:/ /g'`
     for file in $m4list; do


### PR DESCRIPTION
This drops a bunch of unnecessary warnings when built in a minimal build environment.

The only build-dependency is pkgconfig (and regular autotools stuff).

You could probably clean up this section to make the warning (or error) a big more direct (install pkgconfig), but I'm proposing a simple improvement.