### PR TITLE
Replace hardcoded aclocal / automake versions

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -7,9 +7,9 @@
 # tools and you shouldn't use this script. Just call ./configure
 # directly.
 
-ACLOCAL=${ACLOCAL-aclocal-1.13}
+ACLOCAL=${ACLOCAL-aclocal}
 AUTOCONF=${AUTOCONF-autoconf}
-AUTOMAKE=${AUTOMAKE-automake-1.13}
+AUTOMAKE=${AUTOMAKE-automake}
 
 AUTOCONF_REQUIRED_VERSION=2.62
 AUTOMAKE_REQUIRED_VERSION=1.13


### PR DESCRIPTION
The required version check will be done anyway, so there is no need to require a specific binary.